### PR TITLE
removes vent pump pressure lockout

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -28,50 +28,6 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [DataField]
         public VentPressureBound PressureChecks { get; set; } = VentPressureBound.ExternalBound;
 
-        [DataField]
-        public bool UnderPressureLockout { get; set; } = false;
-
-        /// <summary>
-        ///     In releasing mode, do not pump when environment pressure is below this limit.
-        /// </summary>
-        [DataField]
-        public float UnderPressureLockoutThreshold = 80; // this must be tuned in conjunction with atmos.mmos_spacing_speed
-
-        /// <summary>
-        ///     Pressure locked vents still leak a little (leading to eventual pressurization of sealed sections)
-        /// </summary>
-        /// <remarks>
-        ///     Ratio of pressure difference between pipes and atmosphere that will leak each second, in moles.
-        ///     If the pipes are 200 kPa and the room is spaced, at 0.01 UnderPressureLockoutLeaking, the room will fill
-        ///     at a rate of 2 moles / sec. It will then reach 2 kPa (UnderPressureLockoutThreshold) and begin normal
-        ///     filling after about 20 seconds (depending on room size).
-        ///
-        ///     Since we want to prevent automating the work of atmos, the leaking rate of 0.0001f is set to make auto
-        ///     repressurizing of the development map take about 30 minutes using an oxygen tank (high pressure)
-        /// </remarks>
-
-        [DataField]
-        public float UnderPressureLockoutLeaking = 0.0001f;
-        /// <summary>
-        /// Is the vent pressure lockout currently manually disabled?
-        /// </summary>
-        [DataField]
-        public bool IsPressureLockoutManuallyDisabled = false;
-        /// <summary>
-        /// The time when the manual pressure lockout will be reenabled. 
-        /// </summary>
-        [DataField]
-        [AutoPausedField]
-        public TimeSpan ManualLockoutReenabledAt;
-        /// <summary>
-        /// How long the lockout should remain manually disabled after being interacted with.
-        /// </summary>
-        [DataField]
-        public TimeSpan ManualLockoutDisabledDuration = TimeSpan.FromSeconds(30); // Enough time to fill a 5x5 room
-        /// <summary>
-        /// How long the doAfter should take when attempting to manually disable the pressure lockout.
-        /// </summary>
-        public float ManualLockoutDisableDoAfter = 2.0f;
 
         [DataField]
         public float ExternalPressureBound
@@ -143,9 +99,6 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [DataField]
         public float DepressurizePressure = 0;
 
-        // When true, ignore under-pressure lockout. Used to re-fill rooms in air alarm "Fill" mode.
-        [DataField]
-        public bool PressureLockoutOverride = false;
         #endregion
 
         public GasVentPumpData ToAirAlarmData()
@@ -158,7 +111,6 @@ namespace Content.Server.Atmos.Piping.Unary.Components
                 PressureChecks = PressureChecks,
                 ExternalPressureBound = ExternalPressureBound,
                 InternalPressureBound = InternalPressureBound,
-                PressureLockoutOverride = PressureLockoutOverride
             };
         }
 
@@ -170,7 +122,6 @@ namespace Content.Server.Atmos.Piping.Unary.Components
             PressureChecks = data.PressureChecks;
             ExternalPressureBound = data.ExternalPressureBound;
             InternalPressureBound = data.InternalPressureBound;
-            PressureLockoutOverride = data.PressureLockoutOverride;
         }
     }
 }

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentPumpComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentPumpComponent.cs
@@ -13,7 +13,6 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
         public VentPressureBound PressureChecks { get; set; } = VentPressureBound.ExternalBound;
         public float ExternalPressureBound { get; set; } = Atmospherics.OneAtmosphere;
         public float InternalPressureBound { get; set; } = 0f;
-        public bool PressureLockoutOverride { get; set; } = false;
 
         // Presets for 'dumb' air alarm modes
 
@@ -24,7 +23,6 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             PressureChecks = VentPressureBound.ExternalBound,
             ExternalPressureBound = Atmospherics.OneAtmosphere,
             InternalPressureBound = 0f,
-            PressureLockoutOverride = false
         };
 
         public static GasVentPumpData FillModePreset = new GasVentPumpData
@@ -35,7 +33,6 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             PressureChecks = VentPressureBound.ExternalBound,
             ExternalPressureBound = Atmospherics.OneAtmosphere * 50,
             InternalPressureBound = 0f,
-            PressureLockoutOverride = true
         };
 
         public static GasVentPumpData PanicModePreset = new GasVentPumpData
@@ -46,7 +43,6 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             PressureChecks = VentPressureBound.ExternalBound,
             ExternalPressureBound = Atmospherics.OneAtmosphere,
             InternalPressureBound = 0f,
-            PressureLockoutOverride = false
         };
 
         public static GasVentPumpData ReplaceModePreset = new GasVentPumpData
@@ -58,7 +54,6 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             PressureChecks = VentPressureBound.ExternalBound,
             ExternalPressureBound = Atmospherics.OneAtmosphere,
             InternalPressureBound = 0f,
-            PressureLockoutOverride = false
         };
     }
 

--- a/Content.Shared/Atmos/Piping/Unary/Visuals/VentPumpVisuals.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Visuals/VentPumpVisuals.cs
@@ -15,6 +15,5 @@ namespace Content.Shared.Atmos.Visuals
         In,
         Out,
         Welded,
-        Lockout,
     }
 }

--- a/Resources/Locale/en-US/atmos/gas-vent-pump.ftl
+++ b/Resources/Locale/en-US/atmos/gas-vent-pump.ftl
@@ -1,1 +1,0 @@
-gas-vent-pump-uvlo = It is in [color=red]under-pressure lock out[/color].


### PR DESCRIPTION
## what this does
removes the pressure lockout mechanic from vents

## why it's good
it's really annoying and makes life harder.

## how it was tested
booted up the game, vents still work with in a vacuum.


:cl:
- remove: vent pumps no longer have a pressure lockout

