### PR TITLE
faster move speed

### DIFF
--- a/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
+++ b/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
@@ -23,8 +23,8 @@ namespace Content.Shared.Movement.Components
         public const float DefaultFriction = 20f;
         public const float DefaultFrictionNoInput = 20f;
 
-        public const float DefaultBaseWalkSpeed = 2.5f;
-        public const float DefaultBaseSprintSpeed = 4.5f;
+        public const float DefaultBaseWalkSpeed = 4.0f;
+        public const float DefaultBaseSprintSpeed = 7.0f;
 
         [AutoNetworkedField, ViewVariables]
         public float WalkSpeedModifier = 1.0f;

--- a/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
@@ -37,7 +37,7 @@ public sealed partial class StepTriggerComponent : Component
     ///     Entities will only be triggered if their speed exceeds this limit.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float RequiredTriggeredSpeed = 3.5f;
+    public float RequiredTriggeredSpeed = 5.0f;
 
     /// <summary>
     ///     If any entities occupy the blacklist on the same tile then steptrigger won't work.


### PR DESCRIPTION
## what this does
increase base move speed from 4.5/2.5 -> 7.0/4.0, or about 55% faster runing, and 60% faster walking


https://github.com/user-attachments/assets/24ea68cf-a9a0-408d-9fd3-49b0cc211f84



## why it's good
brings the move speed more in line with /vg/station's normal move speed - aka, fast.


## how it was tested
booted up local server, i was faster.

**Changelog**

:cl:
- tweak: increased base move speed

