### PR TITLE
removes atmos temperature caps

### DIFF
--- a/Content.Client/Atmos/UI/GasThermomachineBoundUserInterface.cs
+++ b/Content.Client/Atmos/UI/GasThermomachineBoundUserInterface.cs
@@ -53,7 +53,7 @@ namespace Content.Client.Atmos.UI
                 actual = Math.Min(value, _maxTemp);
             else
                 actual = Math.Max(value, _minTemp);
-            actual = Math.Max(actual, Atmospherics.TCMB);
+            actual = Math.Max(actual, 0.0f);
             if (!MathHelper.CloseTo(actual, value, 0.09))
             {
                 _window?.SetTemperature(actual);

--- a/Content.Server/Atmos/Commands/SetAtmosTemperatureCommand.cs
+++ b/Content.Server/Atmos/Commands/SetAtmosTemperatureCommand.cs
@@ -27,7 +27,7 @@ namespace Content.Server.Atmos.Commands
                 return;
             }
 
-            if (temperature < Atmospherics.TCMB)
+            if (temperature < 0.0f)
             {
                 shell.WriteLine("Invalid temperature.");
                 return;

--- a/Content.Server/Atmos/Commands/SetMapAtmosCommand.cs
+++ b/Content.Server/Atmos/Commands/SetMapAtmosCommand.cs
@@ -54,7 +54,7 @@ public sealed class AddMapAtmosCommand : LocalizedCommands
             return;
         }
 
-        var mix = new GasMixture(Atmospherics.CellVolume) {Temperature = Math.Max(temp, Atmospherics.TCMB)};
+        var mix = new GasMixture(Atmospherics.CellVolume) {Temperature = Math.Max(temp, 0.0f)};
         for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
         {
             if (args.Length == 3 + i)

--- a/Content.Server/Atmos/Commands/SetTemperatureCommand.cs
+++ b/Content.Server/Atmos/Commands/SetTemperatureCommand.cs
@@ -30,7 +30,7 @@ namespace Content.Server.Atmos.Commands
                 return;
             }
 
-            if (temperature < Atmospherics.TCMB)
+            if (temperature < 0.0f)
             {
                 shell.WriteLine("Invalid temperature.");
                 return;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -296,10 +296,10 @@ namespace Content.Server.Atmos.EntitySystems
                     var heat = conductionCoefficient * temperatureDelta * (heatCapacity * sharerHeatCapacity / (heatCapacity + sharerHeatCapacity));
 
                     if (!receiver.Immutable)
-                        receiver.Temperature = MathF.Abs(MathF.Max(receiver.Temperature - heat / heatCapacity, Atmospherics.TCMB));
+                        receiver.Temperature = MathF.Abs(MathF.Max(receiver.Temperature - heat / heatCapacity, 0.0f));
 
                     if (!sharer.Immutable)
-                        sharer.Temperature = MathF.Abs(MathF.Max(sharer.Temperature + heat / sharerHeatCapacity, Atmospherics.TCMB));
+                        sharer.Temperature = MathF.Abs(MathF.Max(sharer.Temperature + heat / sharerHeatCapacity, 0.0f));
                 }
             }
 
@@ -324,9 +324,9 @@ namespace Content.Server.Atmos.EntitySystems
                     var heat = conductionCoefficient * temperatureDelta * (heatCapacity * sharerHeatCapacity / (heatCapacity + sharerHeatCapacity));
 
                     if (!receiver.Immutable)
-                        receiver.Temperature = MathF.Abs(MathF.Max(receiver.Temperature - heat / heatCapacity, Atmospherics.TCMB));
+                        receiver.Temperature = MathF.Abs(MathF.Max(receiver.Temperature - heat / heatCapacity, 0.0f));
 
-                    sharerTemperature = MathF.Abs(MathF.Max(sharerTemperature + heat / sharerHeatCapacity, Atmospherics.TCMB));
+                    sharerTemperature = MathF.Abs(MathF.Max(sharerTemperature + heat / sharerHeatCapacity, 0.0f));
                 }
             }
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
@@ -154,7 +154,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 thermoMachine.TargetTemperature = MathF.Min(args.Temperature, thermoMachine.MaxTemperature);
             else
                 thermoMachine.TargetTemperature = MathF.Max(args.Temperature, thermoMachine.MinTemperature);
-            thermoMachine.TargetTemperature = MathF.Max(thermoMachine.TargetTemperature, 0.0f);
+            thermoMachine.TargetTemperature = MathF.Max(thermoMachine.TargetTemperature, Atmospherics.TCMB);
             _adminLogger.Add(LogType.AtmosTemperatureChanged, $"{ToPrettyString(args.Actor)} set temperature on {ToPrettyString(uid)} to {thermoMachine.TargetTemperature}");
             DirtyUI(uid, thermoMachine);
         }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
@@ -154,7 +154,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 thermoMachine.TargetTemperature = MathF.Min(args.Temperature, thermoMachine.MaxTemperature);
             else
                 thermoMachine.TargetTemperature = MathF.Max(args.Temperature, thermoMachine.MinTemperature);
-            thermoMachine.TargetTemperature = MathF.Max(thermoMachine.TargetTemperature, Atmospherics.TCMB);
+            thermoMachine.TargetTemperature = MathF.Max(thermoMachine.TargetTemperature, 0.0f);
             _adminLogger.Add(LogType.AtmosTemperatureChanged, $"{ToPrettyString(args.Actor)} set temperature on {ToPrettyString(uid)} to {thermoMachine.TargetTemperature}");
             DirtyUI(uid, thermoMachine);
         }

--- a/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
+++ b/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
@@ -28,7 +28,7 @@ namespace Content.Server.Atmos.Reactions
         ///     Minimum temperature requirement.
         /// </summary>
         [DataField("minimumTemperature")]
-        public float MinimumTemperatureRequirement { get; private set; } = Atmospherics.TCMB;
+        public float MinimumTemperatureRequirement { get; private set; } = 0.0f;
 
         /// <summary>
         ///     Minimum energy requirement.

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -41,15 +41,6 @@ namespace Content.Shared.Atmos
         public const float T20C = 293.15f;
 
         /// <summary>
-        ///     Do not allow any gas mixture temperatures to exceed this number. It is occasionally possible
-        ///     to have very small heat capacity (e.g. room that was just unspaced) and for large amounts of
-        ///     energy to be transferred to it, even for a brief moment. However, this messes up subsequent
-        ///     calculations and so cap it here. The physical interpretation is that at this temperature, any
-        ///     gas that you would have transforms into plasma.
-        /// </summary>
-       // public const float Tmax = 262144; // 1/64 of max safe integer, any values above will result in a ~0.03K epsilon
-
-        /// <summary>
         ///     Liters in a cell.
         /// </summary>
         public const float CellVolume = 2500f;

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -47,7 +47,7 @@ namespace Content.Shared.Atmos
         ///     calculations and so cap it here. The physical interpretation is that at this temperature, any
         ///     gas that you would have transforms into plasma.
         /// </summary>
-        public const float Tmax = 262144; // 1/64 of max safe integer, any values above will result in a ~0.03K epsilon
+       // public const float Tmax = 262144; // 1/64 of max safe integer, any values above will result in a ~0.03K epsilon
 
         /// <summary>
         ///     Liters in a cell.

--- a/Content.Shared/Atmos/GasMixture.cs
+++ b/Content.Shared/Atmos/GasMixture.cs
@@ -63,7 +63,7 @@ namespace Content.Shared.Atmos
             {
                 DebugTools.Assert(!float.IsNaN(value));
                 if (!Immutable)
-                    _temperature = MathF.Min(MathF.Max(value, Atmospherics.TCMB), Atmospherics.Tmax);
+                    _temperature = value;
             }
         }
 


### PR DESCRIPTION
## what this does
removes the temperature floor+ceiling of 2.7K and 262144K respectivly

## why it's good
more pipe autism potential

## how it was tested
not too well, honestly, nothing in the game ever gets that hot, atmos is funky, and fires don't really get as hot as /vg/'s

**Changelog**

:cl:
- tweak: atmospherics has no more temperature limits

