### PR TITLE
hotfix puddles

### DIFF
--- a/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
@@ -18,7 +18,7 @@ namespace Content.Server.Chemistry.TileReactions
     public sealed partial class SpillTileReaction : ITileReaction
     {
         [DataField("launchForwardsMultiplier")] private float _launchForwardsMultiplier = 1;
-        [DataField("requiredSlipSpeed")] private float _requiredSlipSpeed = 6;
+        [DataField("requiredSlipSpeed")] private float _requiredSlipSpeed = 9;
         [DataField("paralyzeTime")] private float _paralyzeTime = 1;
 
         /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
mirrors #3, due to a minor inconvenience

## Why / Balance
currently you would slip on any and *all* puddles which is bad obviously  
fixes this behavior to be somewhat consistent so you can't just throw a can of soda at the floor to slip everyone

## Technical details
direct code change

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
no cl no fun