### PR TITLE
/vg/station13 space cleaner behaviour

### DIFF
--- a/Content.Server/Chemistry/TileReactions/CleanTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/CleanTileReaction.cs
@@ -11,26 +11,11 @@ using System.Linq;
 namespace Content.Server.Chemistry.TileReactions;
 
 /// <summary>
-/// Turns all of the reagents on a puddle into water.
+/// Purges all reagents on a tile
 /// </summary>
 [DataDefinition]
 public sealed partial class CleanTileReaction : ITileReaction
 {
-    /// <summary>
-    /// How much it costs to clean 1 unit of reagent.
-    /// </summary>
-    /// <remarks>
-    /// In terms of space cleaner can clean 1 average puddle per 5 units.
-    /// </remarks>
-    [DataField("cleanCost")]
-    public float CleanAmountMultiplier { get; private set; } = 0.25f;
-
-    /// <summary>
-    /// What reagent to replace the tile conents with.
-    /// </summary>
-    [DataField("reagent", customTypeSerializer: typeof(PrototypeIdSerializer<ReagentPrototype>))]
-    public string ReplacementReagent = "Water";
-
     FixedPoint2 ITileReaction.TileReact(TileRef tile,
         ReagentPrototype reagent,
         FixedPoint2 reactVolume,
@@ -40,8 +25,6 @@ public sealed partial class CleanTileReaction : ITileReaction
         var entities = entityManager.System<EntityLookupSystem>().GetLocalEntitiesIntersecting(tile, 0f).ToArray();
         var puddleQuery = entityManager.GetEntityQuery<PuddleComponent>();
         var solutionContainerSystem = entityManager.System<SharedSolutionContainerSystem>();
-        // Multiply as the amount we can actually purge is higher than the react amount.
-        var purgeAmount = reactVolume / CleanAmountMultiplier;
 
         foreach (var entity in entities)
         {
@@ -51,16 +34,9 @@ public sealed partial class CleanTileReaction : ITileReaction
                 continue;
             }
 
-            var purgeable = solutionContainerSystem.SplitSolutionWithout(puddleSolution.Value, purgeAmount, ReplacementReagent, reagent.ID);
-
-            purgeAmount -= purgeable.Volume;
-
-            solutionContainerSystem.TryAddSolution(puddleSolution.Value, new Solution(ReplacementReagent, purgeable.Volume));
-
-            if (purgeable.Volume <= FixedPoint2.Zero)
-                break;
+            solutionContainerSystem.RemoveAllSolution(puddleSolution.Value);
         }
 
-        return (reactVolume / CleanAmountMultiplier - purgeAmount) * CleanAmountMultiplier;
+        return FixedPoint2.Zero;
     }
 }


### PR DESCRIPTION
## What this does

Before change: Space cleaner turns reagents in puddles into water
After change: Space cleaner purges all reagents on tile (/vg/station13 behaviour)

## How it was tested
- Throw some stuff on the floor
- Spray space cleaner on it

**Changelog**
- tweak: Space Cleaner works as it does in /vg/station13

## Why its in Draft

Someone on discord said they preferred the SS14 behaviour and raised a good point about having no choice but to create a puddle. I split this PR off from #21 for separate discussion
![image](https://github.com/user-attachments/assets/4a95f67b-7541-4cc2-9a3f-ad02b92db13f)


