### PR TITLE
crafting menu fuzzy search framework

### DIFF
--- a/Content.Client/Construction/UI/ConstructionMenu.xaml
+++ b/Content.Client/Construction/UI/ConstructionMenu.xaml
@@ -13,6 +13,7 @@
         <BoxContainer Orientation="Vertical" HorizontalExpand="True">
             <BoxContainer Orientation="Horizontal">
                 <Button Name="MenuGridViewButton" ToggleMode="True" Text="{Loc construction-menu-grid-view}"/>
+                <Button Name="FuzzySearchButton" ToggleMode="True" Text="Fuzzy Search"/>
                 <Button Name="FavoriteButton" Visible="false"/>
             </BoxContainer>
             <Control>

--- a/Content.Client/Construction/UI/ConstructionMenu.xaml.cs
+++ b/Content.Client/Construction/UI/ConstructionMenu.xaml.cs
@@ -104,12 +104,12 @@ namespace Content.Client.Construction.UI
             Recipes.OnItemDeselected += _ => RecipeSelected?.Invoke(this, null);
 
             SearchBar.OnTextChanged += _ =>
-                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[OptionCategories.SelectedId] ,FuzzySearchEnabled));
+                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[OptionCategories.SelectedId], FuzzySearchEnabled));
             OptionCategories.OnItemSelected += obj =>
             {
                 OptionCategories.SelectId(obj.Id);
                 SearchBar.SetText(string.Empty);
-                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[obj.Id] ,FuzzySearchEnabled));
+                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[obj.Id], FuzzySearchEnabled));
             };
 
             BuildButton.Text = Loc.GetString("construction-menu-place-ghost");
@@ -122,10 +122,10 @@ namespace Content.Client.Construction.UI
             FavoriteButton.OnPressed += args => RecipeFavorited?.Invoke(this, EventArgs.Empty);
 
             MenuGridViewButton.OnPressed += _ =>
-                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[OptionCategories.SelectedId],FuzzySearchEnabled));
+                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[OptionCategories.SelectedId], FuzzySearchEnabled));
 				
 			FuzzySearchButton.OnPressed += _ =>
-                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[OptionCategories.SelectedId],FuzzySearchEnabled));
+                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[OptionCategories.SelectedId], FuzzySearchEnabled));
 				
         }
 

--- a/Content.Client/Construction/UI/ConstructionMenu.xaml.cs
+++ b/Content.Client/Construction/UI/ConstructionMenu.xaml.cs
@@ -35,7 +35,7 @@ namespace Content.Client.Construction.UI
         ScrollContainer RecipesGridScrollContainer { get; }
         GridContainer RecipesGrid { get; }
 
-        event EventHandler<(string search, string catagory)> PopulateRecipes;
+        event EventHandler<(string search, string catagory, bool fuzzysearch)> PopulateRecipes;
         event EventHandler<ItemList.Item?> RecipeSelected;
         event EventHandler RecipeFavorited;
         event EventHandler<bool> BuildButtonToggled;
@@ -82,11 +82,17 @@ namespace Content.Client.Construction.UI
             get => MenuGridViewButton.Pressed;
             set => MenuGridViewButton.Pressed = value;
         }
+		
+		public bool FuzzySearchEnabled
+		{
+			get => FuzzySearchButton.Pressed;
+            set => FuzzySearchButton.Pressed = value;
+		}
 
         public ConstructionMenu()
         {
-            SetSize = new Vector2(560, 450);
-            MinSize = new Vector2(560, 320);
+            SetSize = new Vector2(620, 450);
+            MinSize = new Vector2(620, 320);
 
             IoCManager.InjectDependencies(this);
             RobustXamlLoader.Load(this);
@@ -98,12 +104,12 @@ namespace Content.Client.Construction.UI
             Recipes.OnItemDeselected += _ => RecipeSelected?.Invoke(this, null);
 
             SearchBar.OnTextChanged += _ =>
-                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[OptionCategories.SelectedId]));
+                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[OptionCategories.SelectedId] ,FuzzySearchEnabled));
             OptionCategories.OnItemSelected += obj =>
             {
                 OptionCategories.SelectId(obj.Id);
                 SearchBar.SetText(string.Empty);
-                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[obj.Id]));
+                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[obj.Id] ,FuzzySearchEnabled));
             };
 
             BuildButton.Text = Loc.GetString("construction-menu-place-ghost");
@@ -116,11 +122,15 @@ namespace Content.Client.Construction.UI
             FavoriteButton.OnPressed += args => RecipeFavorited?.Invoke(this, EventArgs.Empty);
 
             MenuGridViewButton.OnPressed += _ =>
-                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[OptionCategories.SelectedId]));
+                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[OptionCategories.SelectedId],FuzzySearchEnabled));
+				
+			FuzzySearchButton.OnPressed += _ =>
+                PopulateRecipes?.Invoke(this, (SearchBar.Text, Categories[OptionCategories.SelectedId],FuzzySearchEnabled));
+				
         }
 
         public event EventHandler? ClearAllGhosts;
-        public event EventHandler<(string search, string catagory)>? PopulateRecipes;
+        public event EventHandler<(string search, string catagory, bool fuzzysearch) >? PopulateRecipes;
         public event EventHandler<ItemList.Item?>? RecipeSelected;
         public event EventHandler? RecipeFavorited;
         public event EventHandler<bool>? BuildButtonToggled;

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -167,7 +167,7 @@ namespace Content.Client.Construction.UI
             PopulateInfo(_selected);
         }
 		
-		private int checkfuzzysearch(string hostfield,string searchtext){// return an int for futureproofing, if you wanted to sort by likeness, or something. doesn't matter much now, ints are compatible with boolean logic, anyways.
+		private int CheckFuzzySearch(string hostfield,string searchtext){// return an int for futureproofing, if you wanted to sort by likeness, or something. doesn't matter much now, ints are compatible with boolean logic, anyways.
 			int matchedtokens=0;
 			char[] str_seps={' ',':','.',',','/'}; //flatten punctuation.
 			string[] searchtokens = searchtext.Split(str_seps); //turn the search into tokens
@@ -180,9 +180,9 @@ namespace Content.Client.Construction.UI
 		}
 		
 		
-        private void OnViewPopulateRecipes(object? sender, (string search, string catagory, bool fuzzysearch) args)
+        private void OnViewPopulateRecipes(object? sender, (string search, string catagory, bool fuzzySearch) args)
         {
-            var (search, category,fuzzysearch) = args;
+            var (search, category,fuzzySearch) = args;
 
             var recipes = new List<ConstructionPrototype>();
 
@@ -205,7 +205,7 @@ namespace Content.Client.Construction.UI
 
                 if (!string.IsNullOrEmpty(search))
                 {
-                    if ( fuzzysearch? checkfuzzysearch( string.IsNullOrEmpty(recipe.FuzzyName) ? recipe.Name : recipe.FuzzyName,search)==0 :(!recipe.Name.ToLowerInvariant().Contains(search.Trim().ToLowerInvariant())))
+                    if ( fuzzySearch? CheckFuzzySearch( string.IsNullOrEmpty(recipe.FuzzyName) ? recipe.Name : recipe.FuzzyName,search)==0 :(!recipe.Name.ToLowerInvariant().Contains(search.Trim().ToLowerInvariant())))
                         continue;
                 }
 

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -114,7 +114,7 @@ namespace Content.Client.Construction.UI
             _constructionView.RecipeFavorited += (_, _) => OnViewFavoriteRecipe();
 
             PopulateCategories();
-            OnViewPopulateRecipes(_constructionView, (string.Empty, string.Empty));
+            OnViewPopulateRecipes(_constructionView, (string.Empty, string.Empty,false));
         }
 
         public void OnHudCraftingButtonToggled(ButtonToggledEventArgs args)
@@ -166,10 +166,23 @@ namespace Content.Client.Construction.UI
             if (_placementManager.IsActive && !_placementManager.Eraser) UpdateGhostPlacement();
             PopulateInfo(_selected);
         }
-
-        private void OnViewPopulateRecipes(object? sender, (string search, string catagory) args)
+		
+		private int checkfuzzysearch(string hostfield,string searchtext){// return an int for futureproofing, if you wanted to sort by likeness, or something. doesn't matter much now, ints are compatible with boolean logic, anyways.
+			int matchedtokens=0;
+			char[] str_seps={' ',':','.',',','/'}; //flatten punctuation.
+			string[] searchtokens = searchtext.Split(str_seps); //turn the search into tokens
+			
+			foreach (string stoken in searchtokens){
+				if(hostfield.Contains(stoken,StringComparison.OrdinalIgnoreCase)) matchedtokens++; //thanks chatGPT for helping me.
+			}
+			
+			return matchedtokens;
+		}
+		
+		
+        private void OnViewPopulateRecipes(object? sender, (string search, string catagory, bool fuzzysearch) args)
         {
-            var (search, category) = args;
+            var (search, category,fuzzysearch) = args;
 
             var recipes = new List<ConstructionPrototype>();
 
@@ -192,7 +205,7 @@ namespace Content.Client.Construction.UI
 
                 if (!string.IsNullOrEmpty(search))
                 {
-                    if (!recipe.Name.ToLowerInvariant().Contains(search.Trim().ToLowerInvariant()))
+                    if ( fuzzysearch? checkfuzzysearch( string.IsNullOrEmpty(recipe.FuzzyName) ? recipe.Name : recipe.FuzzyName,search)==0 :(!recipe.Name.ToLowerInvariant().Contains(search.Trim().ToLowerInvariant())))
                         continue;
                 }
 
@@ -458,9 +471,9 @@ namespace Content.Client.Construction.UI
             if (_selectedCategory == _favoriteCatName)
             {
                 if (_favoritedRecipes.Count > 0)
-                    OnViewPopulateRecipes(_constructionView, (string.Empty, _favoriteCatName));
+                    OnViewPopulateRecipes(_constructionView, (string.Empty, _favoriteCatName,false));
                 else
-                    OnViewPopulateRecipes(_constructionView, (string.Empty, string.Empty));
+                    OnViewPopulateRecipes(_constructionView, (string.Empty, string.Empty,false));
             }
 
             PopulateInfo(_selected);

--- a/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
@@ -24,6 +24,12 @@ public sealed partial class ConstructionPrototype : IPrototype
     public string Name = string.Empty;
 
     /// <summary>
+    ///     The string used when performing a fuzzy search
+    /// </summary>
+    [DataField("fuzzyname")]
+    public string FuzzyName = string.Empty;
+	
+    /// <summary>
     ///     "Useful" description displayed in the construction GUI.
     /// </summary>
     [DataField("description")]


### PR DESCRIPTION
## What this does
adds a button for fuzzy searching and the relevant code to support it. this does not actually add any proper fuzzy search strings, but it falls back to using names so there's no errors.
![Capture](https://github.com/user-attachments/assets/c9a7c68f-ccb3-451d-84b3-298df62a9878)
![Capture2](https://github.com/user-attachments/assets/185dab2e-14cf-4d73-9c3f-a2d2aec213d5)


## Why it's good
makes the UI easier to use, doesn't require players know exact names

## How it was tested
opened test server, made sure no errors

**Changelog**
:cl:
- add: Added a fuzzy search framework to the crafting menu

