### PR TITLE
Adds sexes to vox

### DIFF
--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -11,8 +11,6 @@
   maleFirstNames: names_vox
   femaleFirstNames: names_vox
   naming: First
-  sexes:
-  - Unsexed
 
 - type: speciesBaseSprites
   id: MobVoxSprites


### PR DESCRIPTION
## What this does
For some reason vox are asexual/non-gendered in ss14. Cortical stacks, I suppose. Vox can now choose a sex at character creation like the respectable species can.

## Why it's good
I HATE THE CORTICAL STACKS I HATE THE CORTICAL STACKS

## How it was tested
I booted myself to lobby and choose a sex. It didn't crash

**Changelog**
:cl:
- tweak: vox are no longer asexual