### PR TITLE
Adds sexes to vox

### DIFF
--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -11,8 +11,6 @@
   maleFirstNames: names_vox
   femaleFirstNames: names_vox
   naming: First
-  sexes:
-  - Unsexed
 
 - type: speciesBaseSprites
   id: MobVoxSprites


### PR DESCRIPTION
## What this does
For some reason vox are asexual/non-gendered in ss14. Cortical stacks, I suppose. Vox can now choose a sex at character creation like the respectable species can.

## Why it's good
I HATE THE CORTICAL STACKS I HATE THE CORTICAL STACKS

## How it was tested
Joined as a vox and didn't crash the game

**Changelog**
:cl:
- tweak: vox are no longer asexual
