### PR TITLE
udders no longer crash the game

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -118,9 +118,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
     {
         if (entity is not null)
         {
-            DebugTools.Assert(TryGetSolution(container, name, out var debugEnt)
-                              && debugEnt.Value.Owner == entity.Value.Owner);
-            return true;
+            return TryGetSolution(container, name, out var debugEnt) && debugEnt.Value.Owner == entity.Value.Owner;
         }
 
         return TryGetSolution(container, name, out entity);


### PR DESCRIPTION

## What this does
prevents a client crash (presumably debug only) due to a failed assert. this make it just not assert anything

## Why it's good
it makes testing less annoying when playing actual maps

## How it was tested
booted up the game, no crash.

**Changelog**
:cl:
- fix: debug clients should no longer crash randomly
