### PR TITLE
Mini Event Timer

### DIFF
--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -10,14 +10,14 @@ public sealed partial class RampingStationEventSchedulerComponent : Component
     ///     Max chaos chosen for a round will deviate from this
     /// </summary>
     [DataField]
-    public float AverageChaos = 12f;
+    public float AverageChaos = 8f;
 
     /// <summary>
     ///     Average time (in minutes) for when the ramping event scheduler should stop increasing the chaos modifier.
     ///     Close to how long you expect a round to last, so you'll probably have to tweak this on downstreams.
     /// </summary>
     [DataField]
-    public float AverageEndTime = 90f;
+    public float AverageEndTime = 300f;
 
     [DataField]
     public float EndTime;

--- a/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
@@ -17,7 +17,7 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
     /// </summary>
     public float GetChaosModifier(EntityUid uid, RampingStationEventSchedulerComponent component)
     {
-        var roundTime = (float) _gameTicker.RoundDuration().TotalSeconds;
+        var roundTime = (float)_gameTicker.RoundDuration().TotalSeconds;
         if (roundTime > component.EndTime)
             return component.MaxChaos;
 
@@ -69,7 +69,7 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
     {
         var mod = GetChaosModifier(uid, component);
 
-        // 4-12 minutes baseline. Will get faster over time as the chaos mod increases.
-        component.TimeUntilNextEvent = _random.NextFloat(240f / mod, 720f / mod);
+        // 10-30 minutes baseline. Will get faster over time as the chaos mod increases.
+        component.TimeUntilNextEvent = _random.NextFloat(600f / mod, 1800f / mod);
     }
 }


### PR DESCRIPTION
Events trigger too often.
I just found a halfway decent solution, since I don't want to try figure out a better replacement for that code right now.

## What this does
![image](https://github.com/user-attachments/assets/638a521e-83cb-4a15-915d-8ea3afce87f9)

## Why it's good
Instead of having a random event triggering ***every 36 seconds*** after 90 minutes of uptime, it will be at a much more reasonable 6 minute average trigger time.

## How it was tested
It compiles. Don't know how to test things in SS14 yet, since it shoves you into a demo room instead of an actual local host server. Events are disabled in the test room.

**Changelog**

:cl:
- tweak: Extended delay on random event procs
